### PR TITLE
Added redis/resque configs

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,5 @@
+$redis = Redis.new(
+	url: ENV.fetch("REDIS_URL", "redis://localhost:6379"),
+)
+Redis.current = $redis
+Resque.redis = $redis


### PR DESCRIPTION
I spun up a Droplet on Digital Ocean to run our redis server. I created a redis instance on the Droplet and set it to bind to any port and also set the password (which can be found in 1Password). I created a new initializer for redis and set the Environment variable to fetch `REDIS_URL` which is set in Heroku, but if nothing is set, it defaults to redis://Localhost:6379 (so, your local environment). Now, whenever `Redis.current` or `Resque.redis` is called, it connects to the redis instance.