### PR TITLE
Update Sprockets to non-vulnerable version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       tilt (>= 1.3, < 3)
     spring (2.0.2)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -286,4 +286,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
This is related to [CVE-2018-3760][CVE].

[CVE]: https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k