### PR TITLE
Update loofah due to CVE-2018-16468

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -104,7 +104,7 @@ GEM
     minitest (5.11.3)
     mono_logger (1.1.0)
     multi_json (1.13.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     pg (0.21.0)
@@ -286,4 +286,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.16.4
+   1.17.1


### PR DESCRIPTION
[CVE-2018-16468]: https://nvd.nist.gov/vuln/detail/CVE-2018-16468